### PR TITLE
Feature/news

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,6 +1,7 @@
 import { announcement } from "./announcement";
 import { directory } from "./directory";
-import { tag } from "./tag";
+import { news } from "./news";
 import { person } from "./person";
+import { tag } from "./tag";
 
-export const server = { announcement, directory, tag, person };
+export const server = { announcement, directory, news, tag, person };

--- a/src/actions/news.ts
+++ b/src/actions/news.ts
@@ -1,0 +1,163 @@
+import {
+  addAttachmentInputSchema,
+  createNewsInputSchema,
+  deleteNewsInputSchema,
+  getManyNewsInputSchema,
+  removeAttachmentInputSchema,
+  updateNewsInputSchema,
+  updatePreviewImageInputSchema,
+} from "@/core/news/schema";
+import { newsUsecase } from "@/core/news/usecase";
+import { ActionError, defineAction } from "astro:actions";
+import { z } from "astro:schema";
+import { handleError, isAuthenticated } from "./shared";
+
+export const news = {
+  create: defineAction({
+    input: createNewsInputSchema,
+    handler: async (input, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        const result = await newsUsecase.create(input);
+        return result;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  update: defineAction({
+    input: updateNewsInputSchema,
+    handler: async (input, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        await newsUsecase.update(input);
+        return;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  updatePreviewImage: defineAction({
+    accept: "form",
+    input: updatePreviewImageInputSchema,
+    handler: async (input, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        await newsUsecase.updatePreviewImage(input);
+        return;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  addAttachment: defineAction({
+    accept: "form",
+    input: addAttachmentInputSchema,
+    handler: async (input, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        await newsUsecase.addAttachment(input);
+        return;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  removeAttachment: defineAction({
+    input: removeAttachmentInputSchema,
+    handler: async (input, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        await newsUsecase.removeAttachment(input);
+        return;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  delete: defineAction({
+    input: deleteNewsInputSchema,
+    handler: async (input, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        await newsUsecase.deleteNews(input);
+        return;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  getById: defineAction({
+    input: z.string().uuid(),
+    handler: async (id, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        const result = await newsUsecase.getById(id);
+        if (!result) {
+          throw new ActionError({
+            code: "NOT_FOUND",
+            message: "News not found",
+          });
+        }
+        return result;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  getMany: defineAction({
+    input: getManyNewsInputSchema,
+    handler: async (input, ctx) => {
+      const { success, error } = isAuthenticated(ctx);
+      if (!success) throw error;
+      try {
+        const result = await newsUsecase.getMany(input);
+        return result;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  publish: defineAction({
+    input: z.string().uuid(),
+    handler: async (id, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        await newsUsecase.publish(id);
+        return;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+
+  unpublish: defineAction({
+    input: z.string().uuid(),
+    handler: async (id, ctx) => {
+      try {
+        const { success, error } = isAuthenticated(ctx);
+        if (!success) throw error;
+        await newsUsecase.unpublish(id);
+        return;
+      } catch (error) {
+        throw handleError(error, ctx);
+      }
+    },
+  }),
+};

--- a/src/components/news/admin/create-news-sheet-content.tsx
+++ b/src/components/news/admin/create-news-sheet-content.tsx
@@ -1,0 +1,109 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { createNewsInputSchema } from "@/core/news/schema";
+import { useCreateNews } from "@/hooks/news/mutation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { z } from "astro:schema";
+import { Loader2 } from "lucide-react";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+const defaultValues = {
+  title: "",
+  body: "",
+};
+
+const createNewsFormSchema = createNewsInputSchema;
+
+export const CreateNewsSheetContent: React.FC<{
+  onClose?: () => void;
+}> = ({ onClose }) => {
+  const form = useForm<z.infer<typeof createNewsFormSchema>>({
+    resolver: zodResolver(createNewsFormSchema),
+    defaultValues,
+  });
+
+  const { mutate, isPending } = useCreateNews();
+
+  const createNews = (data: z.infer<typeof createNewsFormSchema>) =>
+    mutate(data, {
+      onSuccess: () => {
+        toast.success("สร้างข่าวสำเร็จ");
+        form.reset(defaultValues);
+        onClose?.();
+      },
+      onError: (error) => {
+        toast.error(`สร้างข่าวล้มเหลว: ${error.message}`);
+      },
+    });
+
+  return (
+    <SheetContent className="w-full sm:w-[480px]">
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit((data) => createNews(data))}
+          className="w-full flex flex-col h-full"
+        >
+          <SheetHeader>
+            <SheetTitle>สร้างข่าวใหม่</SheetTitle>
+            <SheetDescription>
+              กรอกข้อมูลข่าวเพื่อสร้างข่าวใหม่
+            </SheetDescription>
+          </SheetHeader>
+          <div className="grid gap-4 px-4">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>หัวข้อ</FormLabel>
+                  <FormControl>
+                    <Input placeholder="หัวข้อข่าว" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="body"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>เนื้อหาข่าว</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="เนื้อหาข่าว" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <SheetFooter>
+            <Button type="submit" className="w-full" disabled={isPending}>
+              สร้างข่าว{" "}
+              {isPending && <Loader2 className="ml-2 h-4 w-4 animate-spin" />}
+            </Button>
+          </SheetFooter>
+        </form>
+      </Form>
+    </SheetContent>
+  );
+};

--- a/src/components/news/admin/edit-news-sheet-content.tsx
+++ b/src/components/news/admin/edit-news-sheet-content.tsx
@@ -1,0 +1,373 @@
+// External libraries
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "astro:schema";
+import { Paperclip, X } from "lucide-react";
+import { memo, useCallback, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+// Internal components
+import { LoaderButton } from "@/components/common/loader-button";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+
+// Config and core
+import { Config } from "@/config";
+import {
+  addAttachmentInputSchema,
+  updateNewsInputSchema,
+  updatePreviewImageInputSchema,
+  type News,
+} from "@/core/news/schema";
+
+// Hooks
+import { Loader } from "@/components/common/loader";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import {
+  useAddNewsAttachment,
+  useRemoveNewsAttachment,
+  useUpdateNews,
+  useUpdateNewsPreviewImage,
+} from "@/hooks/news/mutation";
+import { useGetNewsById } from "@/hooks/news/queries";
+
+export const EditNewsSheetContent: React.FC<{
+  onClose: () => void;
+  id: string | undefined;
+}> = ({ onClose, id }) => {
+  const { data: news, isPending, error } = useGetNewsById({ id });
+  return (
+    <SheetContent className="w-full sm:w-[540px] lg:w-[700px] xl:w-[900px] overflow-hidden">
+      <SheetHeader>
+        <SheetTitle>แก้ไขข่าว</SheetTitle>
+        <SheetDescription>แก้ไขรายละเอียดข่าว</SheetDescription>
+      </SheetHeader>
+      <ScrollArea className="px-4 pb-8 overflow-y-auto">
+        <div className="space-y-4">
+          {error ? (
+            <ErrorAlert>Error loading news: {error.message}</ErrorAlert>
+          ) : isPending || !news ? (
+            <Loader />
+          ) : (
+            <>
+              <MetadataForm initialData={news} />
+              <Separator />
+              <PreviewImageForm
+                previewImageUrl={
+                  news?.previewImage
+                    ? Config.getFileURL(news?.previewImage?.id)
+                    : undefined
+                }
+                id={news.id}
+              />
+              <Separator />
+              <AttachmentForm id={news.id} attachments={news.attachments} />
+            </>
+          )}
+        </div>
+      </ScrollArea>
+    </SheetContent>
+  );
+};
+
+const updateNewsFormSchema = updateNewsInputSchema.omit({
+  id: true,
+});
+
+// Form component for updating news metadata
+const MetadataForm = memo(({ initialData }: { initialData: News }) => {
+  const form = useForm({
+    resolver: zodResolver(updateNewsFormSchema),
+    defaultValues: {
+      title: initialData.title,
+      body: initialData.body ?? undefined,
+    },
+  });
+
+  const { mutate, isPending } = useUpdateNews();
+
+  // Handler for form submission, memoized to prevent recreation
+  const handleSubmit = useCallback(
+    (data: z.infer<typeof updateNewsFormSchema>) => {
+      console.log(data);
+      mutate(
+        { ...data, id: initialData.id },
+        {
+          onSuccess: () => {
+            toast.success("แก้ไขข่าวสำเร็จ");
+          },
+          onError: () => {
+            toast.error("แก้ไขข่าวไม่สำเร็จ");
+          },
+        },
+      );
+    },
+    [mutate, initialData.id],
+  );
+
+  return (
+    <Form {...form}>
+      <form className="grid gap-4" onSubmit={form.handleSubmit(handleSubmit)}>
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>หัวข้อ</FormLabel>
+              <FormControl>
+                <Input placeholder="หัวข้อข่าว" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="body"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>เนื้อหา</FormLabel>
+              <FormControl>
+                <Textarea placeholder="เนื้อหาข่าว" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <LoaderButton type="submit" isLoading={isPending}>
+          บันทึก
+        </LoaderButton>
+      </form>
+    </Form>
+  );
+});
+
+const previewImageFormSchema = updatePreviewImageInputSchema.omit({ id: true });
+// Form component for updating news preview image
+const PreviewImageForm = memo(
+  ({ previewImageUrl, id }: { previewImageUrl?: string; id: string }) => {
+    const form = useForm({
+      resolver: zodResolver(previewImageFormSchema),
+    });
+    const { mutate, isPending } = useUpdateNewsPreviewImage();
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // Handler for updating preview image, memoized to prevent recreation
+    const update = useCallback(
+      (data: z.infer<typeof previewImageFormSchema>) =>
+        mutate(
+          { ...data, id },
+          {
+            onSuccess: () => {
+              toast.success("อัปเดตภาพปกสำเร็จ");
+              fileInputRef.current!.value = "";
+            },
+            onError: () => {
+              toast.error("อัปเดตภาพปกไม่สำเร็จ");
+            },
+          },
+        ),
+      [mutate, id],
+    );
+
+    return (
+      <div className="space-y-4">
+        <AspectRatio
+          ratio={16 / 9}
+          className="w-full rounded-md overflow-hidden bg-muted"
+        >
+          {previewImageUrl && (
+            <img
+              src={previewImageUrl}
+              alt="Preview Image"
+              className="object-cover w-full h-full"
+            />
+          )}
+        </AspectRatio>
+        <Form {...form}>
+          <form className="grid gap-4" onSubmit={form.handleSubmit(update)}>
+            <FormField
+              control={form.control}
+              name="file"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>ภาพปก</FormLabel>
+                  <FormControl>
+                    <Input
+                      ref={fileInputRef}
+                      type="file"
+                      onChange={(e) => field.onChange(e.target.files?.[0])}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <LoaderButton type="submit" isLoading={isPending}>
+              บันทึกภาพปก
+            </LoaderButton>
+          </form>
+        </Form>
+      </div>
+    );
+  },
+);
+
+const addAttachmentFormDefaultValues = {
+  label: "",
+  file: undefined as any,
+};
+
+const addAttachmentFormSchema = addAttachmentInputSchema.omit({ id: true });
+
+// Form component for managing news attachments
+const AttachmentForm = memo(
+  ({ attachments, id }: { id: string; attachments: News["attachments"] }) => {
+    const form = useForm({
+      resolver: zodResolver(addAttachmentFormSchema),
+      defaultValues: addAttachmentFormDefaultValues,
+    });
+    const [removingId, setRemovingId] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const { mutate: _add, isPending: isAdding } = useAddNewsAttachment();
+    const { mutate: _remove, isPending: isRemoving } =
+      useRemoveNewsAttachment();
+
+    const resetForm = useCallback(() => {
+      form.reset(addAttachmentFormDefaultValues);
+      fileInputRef.current!.value = "";
+    }, [form]);
+
+    // Handler for adding attachment, memoized to prevent recreation
+    const add = useCallback(
+      (data: z.infer<typeof addAttachmentFormSchema>) =>
+        _add(
+          { ...data, id },
+          {
+            onSuccess: () => {
+              toast.success("เพิ่มไฟล์แนบสำเร็จ");
+              resetForm();
+            },
+            onError: () => {
+              toast.error("เพิ่มไฟล์แนบไม่สำเร็จ");
+            },
+          },
+        ),
+      [_add, id, resetForm],
+    );
+
+    // Handler for removing attachment, memoized to prevent recreation
+    const remove = useCallback(
+      ({ attachmentId }: { attachmentId: string }) => {
+        setRemovingId(attachmentId);
+        _remove(
+          { attachmentId, id },
+          {
+            onSuccess: () => {
+              toast.success("ลบไฟล์แนบสำเร็จ");
+            },
+            onError: () => {
+              toast.error("ลบไฟล์แนบไม่สำเร็จ");
+            },
+            onSettled: () => {
+              setRemovingId(null);
+            },
+          },
+        );
+      },
+      [_remove, id],
+    );
+
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          {attachments?.map((attachment) => (
+            <div
+              key={attachment.id}
+              className="flex items-center justify-between px-2 py-1 border rounded gap-1 w-full"
+            >
+              <div className="flex items-center gap-2 flex-1 min-w-0">
+                <Paperclip className="w-3.5 h-3.5 text-muted-foreground" />
+                <a
+                  href={Config.getFileURL(attachment.id)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 text-sm underline overflow-hidden text-ellipsis"
+                >
+                  {attachment.label}
+                </a>
+              </div>
+              <LoaderButton
+                className="w-7 h-7"
+                inplace
+                variant="ghost"
+                size="icon"
+                isLoading={isRemoving && removingId === attachment.id}
+                onClick={() => remove({ attachmentId: attachment.id })}
+                type="button"
+              >
+                <X className="w-4 h-4" />
+              </LoaderButton>
+            </div>
+          ))}
+        </div>
+        <Form {...form}>
+          <form className="grid gap-4" onSubmit={form.handleSubmit(add)}>
+            <FormField
+              control={form.control}
+              name="label"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>ป้ายชื่อ</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="ป้ายชื่อไฟล์แนบ" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="file"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>ไฟล์</FormLabel>
+                  <FormControl>
+                    <Input
+                      ref={fileInputRef}
+                      type="file"
+                      onChange={(e) => field.onChange(e.target.files?.[0])}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <LoaderButton type="submit" isLoading={isAdding}>
+              เพิ่มไฟล์แนบ
+            </LoaderButton>
+          </form>
+        </Form>
+      </div>
+    );
+  },
+);

--- a/src/components/news/admin/edit-news-sheet-content.tsx
+++ b/src/components/news/admin/edit-news-sheet-content.tsx
@@ -1,7 +1,7 @@
 // External libraries
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "astro:schema";
-import { Paperclip, X } from "lucide-react";
+import { X } from "lucide-react";
 import { memo, useCallback, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -233,7 +233,6 @@ const PreviewImageForm = memo(
 );
 
 const addAttachmentFormDefaultValues = {
-  label: "",
   file: undefined as any,
 };
 
@@ -299,34 +298,28 @@ const AttachmentForm = memo(
 
     return (
       <div className="space-y-6">
-        <div className="space-y-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
           {attachments?.map((attachment) => (
-            <div
-              key={attachment.id}
-              className="flex items-center justify-between px-2 py-1 border rounded gap-1 w-full"
-            >
-              <div className="flex items-center gap-2 flex-1 min-w-0">
-                <Paperclip className="w-3.5 h-3.5 text-muted-foreground" />
-                <a
-                  href={Config.getFileURL(attachment.id)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 text-sm underline overflow-hidden text-ellipsis"
-                >
-                  {attachment.label}
-                </a>
+            <div key={attachment.id} className="relative group">
+              <div className="aspect-square rounded-lg overflow-hidden bg-muted">
+                <img
+                  src={Config.getFileURL(attachment.file.id)}
+                  alt={attachment.label}
+                  className="w-full h-full object-cover"
+                />
               </div>
-              <LoaderButton
-                className="w-7 h-7"
-                inplace
-                variant="ghost"
-                size="icon"
-                isLoading={isRemoving && removingId === attachment.id}
-                onClick={() => remove({ attachmentId: attachment.id })}
-                type="button"
-              >
-                <X className="w-4 h-4" />
-              </LoaderButton>
+              <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/50 rounded-lg">
+                <LoaderButton
+                  className="w-8 h-8 bg-white/90 hover:bg-white text-black rounded-full"
+                  inplace
+                  size="icon"
+                  isLoading={isRemoving && removingId === attachment.id}
+                  onClick={() => remove({ attachmentId: attachment.id })}
+                  type="button"
+                >
+                  <X className="w-4 h-4" />
+                </LoaderButton>
+              </div>
             </div>
           ))}
         </div>
@@ -334,27 +327,15 @@ const AttachmentForm = memo(
           <form className="grid gap-4" onSubmit={form.handleSubmit(add)}>
             <FormField
               control={form.control}
-              name="label"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>ป้ายชื่อ</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="ป้ายชื่อไฟล์แนบ" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
               name="file"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>ไฟล์</FormLabel>
+                  <FormLabel>รูปภาพเพิ่มเติม</FormLabel>
                   <FormControl>
                     <Input
                       ref={fileInputRef}
                       type="file"
+                      accept="image/*"
                       onChange={(e) => field.onChange(e.target.files?.[0])}
                     />
                   </FormControl>
@@ -363,7 +344,7 @@ const AttachmentForm = memo(
               )}
             />
             <LoaderButton type="submit" isLoading={isAdding}>
-              เพิ่มไฟล์แนบ
+              เพิ่มรูปภาพ
             </LoaderButton>
           </form>
         </Form>

--- a/src/components/news/admin/news-action-context.tsx
+++ b/src/components/news/admin/news-action-context.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+
+type NewsActions =
+  | {
+      type: "create";
+    }
+  | {
+      type: "update";
+      id: string;
+    }
+  | {
+      type: "delete";
+      id: string;
+    }
+  | { type: "publish"; id: string }
+  | { type: "unpublish"; id: string };
+
+type NewsActionContextType = {
+  newsAction: NewsActions | null;
+  setNewsAction: (action: NewsActions | null) => void;
+};
+
+const NewsActionContext = React.createContext<NewsActionContextType>({
+  newsAction: null,
+  setNewsAction: () => {},
+});
+
+export const useNewsAction = () => React.useContext(NewsActionContext);
+
+export const NewsActionProvider: React.FC = () => {
+  const [newsAction, setNewsAction] = React.useState<NewsActions | null>(null);
+
+  return (
+    <NewsActionContext.Provider value={{ newsAction, setNewsAction }}>
+      <Outlet />
+    </NewsActionContext.Provider>
+  );
+};
+
+export const isCreateNewsAction = (
+  action: NewsActions | null,
+): action is { type: "create" } => action?.type === "create";
+
+export const isUpdateNewsAction = (
+  action: NewsActions | null,
+): action is { type: "update"; id: string } => action?.type === "update";
+
+export const isDeleteNewsAction = (
+  action: NewsActions | null,
+): action is { type: "delete"; id: string } => action?.type === "delete";
+
+export const isPublishNewsAction = (
+  action: NewsActions | null,
+): action is { type: "publish"; id: string } => action?.type === "publish";
+
+export const isUnpublishNewsAction = (
+  action: NewsActions | null,
+): action is { type: "unpublish"; id: string } => action?.type === "unpublish";

--- a/src/components/news/admin/news-table-definition.tsx
+++ b/src/components/news/admin/news-table-definition.tsx
@@ -1,0 +1,85 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { News } from "@/core/news/schema";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Edit, Eye, EyeOff, Paperclip, Trash } from "lucide-react";
+import { useNewsAction } from "./news-action-context";
+
+export const newsColumns: ColumnDef<News>[] = [
+  {
+    accessorKey: "title",
+    header: "หัวข้อ",
+  },
+  {
+    accessorKey: "published",
+    header: "สถานะ",
+    cell: ({ row }) => (
+      <Badge variant={row.original.publishedAt ? "default" : "outline"}>
+        {row.original.publishedAt ? "เผยแพร่แล้ว" : "ร่าง"}
+      </Badge>
+    ),
+  },
+  {
+    id: "attachments",
+    header: "ไฟล์แนบ",
+    cell: ({ row }) => {
+      const numAttachments = row.original.attachments?.length || 0;
+
+      return (
+        <Badge variant="outline">
+          <Paperclip className="inline mr-2" />
+          {numAttachments}
+        </Badge>
+      );
+    },
+  },
+  {
+    id: "actions",
+    header: () => <span className="sr-only">การจัดการ</span>,
+    cell: ({ row }) => {
+      const { setNewsAction, newsAction } = useNewsAction();
+      return (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              if (newsAction) return;
+              setNewsAction({ type: "update", id: row.original.id });
+            }}
+          >
+            <Edit className="w-4 h-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              if (newsAction) return;
+              setNewsAction({ type: "delete", id: row.original.id });
+            }}
+          >
+            <Trash className="w-4 h-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              if (newsAction) return;
+              setNewsAction(
+                row.original.publishedAt
+                  ? { type: "unpublish", id: row.original.id }
+                  : { type: "publish", id: row.original.id },
+              );
+            }}
+          >
+            {row.original.publishedAt ? (
+              <EyeOff className="w-4 h-4" />
+            ) : (
+              <Eye className="w-4 h-4" />
+            )}
+          </Button>
+        </div>
+      );
+    },
+  },
+];

--- a/src/components/news/admin/news-table-definition.tsx
+++ b/src/components/news/admin/news-table-definition.tsx
@@ -21,13 +21,13 @@ export const newsColumns: ColumnDef<News>[] = [
   },
   {
     id: "attachments",
-    header: "ไฟล์แนบ",
+    header: "รูปภาพเพิ่มเติม",
     cell: ({ row }) => {
       const numAttachments = row.original.attachments?.length || 0;
 
       return (
         <Badge variant="outline">
-          <Paperclip className="inline mr-2" />
+          <Paperclip className="inline mr-2 w-3 h-3" />
           {numAttachments}
         </Badge>
       );

--- a/src/components/news/news-card.tsx
+++ b/src/components/news/news-card.tsx
@@ -1,0 +1,53 @@
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { Button } from "@/components/ui/button";
+import { Card, CardFooter } from "@/components/ui/card";
+import { Config } from "@/config";
+import type { News } from "@/core/news/schema";
+import { formatDate } from "@/lib/utils/date";
+
+interface NewsCardProps {
+  news: News;
+}
+
+export function NewsCard({ news }: NewsCardProps) {
+  return (
+    <Card className="overflow-hidden p-0 gap-0">
+      {/* Preview Image */}
+      <AspectRatio ratio={16 / 9}>
+        {news.previewImage ? (
+          <img
+            src={Config.getFileURL(news.previewImage.id)}
+            alt={news.title}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full bg-muted flex items-center justify-center">
+            <div className="text-muted-foreground text-sm">ไม่มีรูปภาพ</div>
+          </div>
+        )}
+      </AspectRatio>
+
+      {/* Footer */}
+      <CardFooter className="flex flex-col items-start gap-3 p-4">
+        <div className="w-full">
+          <h3 className="font-semibold text-lg line-clamp-2 mb-1">
+            {news.title}
+          </h3>
+          {news.publishedAt && (
+            <p className="text-sm text-muted-foreground">
+              เผยแพร่เมื่อ {formatDate(news.publishedAt)}
+            </p>
+          )}
+        </div>
+
+        <Button
+          variant="link"
+          className="w-auto p-0 h-auto text-sm text-secondary-foreground hover:underline self-start"
+          asChild
+        >
+          <a href={`/news/${news.id}`}>ดูรายละเอียด →</a>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/core/news/schema.ts
+++ b/src/core/news/schema.ts
@@ -1,0 +1,63 @@
+import type { Post } from "@/db/schema";
+import { z } from "astro:schema";
+import {
+  MAX_IMAGE_SIZE_MB,
+  SUPPORTED_IMAGE_TYPES,
+} from "../shared/constants";
+import {
+  createPostInputSchema,
+  deletePostInputSchema as PostDeletePostInputSchema,
+  getManyPostsInputSchema as PostGetManyPostsInputSchema,
+  removeAttachmentInputSchema as PostRemoveAttachmentInputSchema,
+  updatePreviewImageInputSchema as PostUpdatePreviewImageInputSchema,
+  updatePostInputSchema,
+} from "../post/schema";
+
+export type News = Post;
+
+export const createNewsInputSchema = createPostInputSchema
+  .omit({ type: true, tags: true });
+
+export type createNewsInput = z.infer<typeof createNewsInputSchema>;
+
+export const updateNewsInputSchema = updatePostInputSchema.omit({
+  type: true,
+  tags: true,
+});
+
+export type updateNewsInput = z.infer<typeof updateNewsInputSchema>;
+
+export const updatePreviewImageInputSchema = PostUpdatePreviewImageInputSchema;
+
+export type UpdatePreviewImage = z.infer<typeof updatePreviewImageInputSchema>;
+
+export const addAttachmentInputSchema = z.object({
+  id: z.string().uuid(),
+  label: z.string().min(1),
+  file: z
+    .instanceof(File)
+    .refine(
+      (file) => SUPPORTED_IMAGE_TYPES.includes(file.type),
+      "Unsupported image type",
+    )
+    .refine(
+      (file) => file.size <= MAX_IMAGE_SIZE_MB * 1024 * 1024,
+      `Image size must be less than ${MAX_IMAGE_SIZE_MB} MB`,
+    ),
+});
+
+export type AddAttachmentInput = z.infer<typeof addAttachmentInputSchema>;
+
+export const removeAttachmentInputSchema = PostRemoveAttachmentInputSchema;
+
+export type RemoveAttachmentInput = z.infer<typeof removeAttachmentInputSchema>;
+
+export const deleteNewsInputSchema = PostDeletePostInputSchema;
+
+export type DeleteNewsInput = z.infer<typeof deleteNewsInputSchema>;
+
+export const getManyNewsInputSchema = PostGetManyPostsInputSchema.omit({
+  tags: true,
+});
+
+export type GetManyNewsInput = z.infer<typeof getManyNewsInputSchema>;

--- a/src/core/news/schema.ts
+++ b/src/core/news/schema.ts
@@ -1,10 +1,6 @@
 import type { Post } from "@/db/schema";
 import { z } from "astro:schema";
 import {
-  MAX_IMAGE_SIZE_MB,
-  SUPPORTED_IMAGE_TYPES,
-} from "../shared/constants";
-import {
   createPostInputSchema,
   deletePostInputSchema as PostDeletePostInputSchema,
   getManyPostsInputSchema as PostGetManyPostsInputSchema,
@@ -12,11 +8,14 @@ import {
   updatePreviewImageInputSchema as PostUpdatePreviewImageInputSchema,
   updatePostInputSchema,
 } from "../post/schema";
+import { MAX_IMAGE_SIZE_MB, SUPPORTED_IMAGE_TYPES } from "../shared/constants";
 
 export type News = Post;
 
-export const createNewsInputSchema = createPostInputSchema
-  .omit({ type: true, tags: true });
+export const createNewsInputSchema = createPostInputSchema.omit({
+  type: true,
+  tags: true,
+});
 
 export type createNewsInput = z.infer<typeof createNewsInputSchema>;
 
@@ -33,7 +32,7 @@ export type UpdatePreviewImage = z.infer<typeof updatePreviewImageInputSchema>;
 
 export const addAttachmentInputSchema = z.object({
   id: z.string().uuid(),
-  label: z.string().min(1),
+  label: z.string().optional(),
   file: z
     .instanceof(File)
     .refine(

--- a/src/core/news/usecase.ts
+++ b/src/core/news/usecase.ts
@@ -1,0 +1,104 @@
+import { postUsecase } from "@/core/post/usecase";
+import type { Post } from "@/db/schema";
+import { db } from "@/db";
+import { posts } from "@/db/schema";
+import { getFileStore } from "@/lib/storage";
+import { eq, sql } from "drizzle-orm";
+import type { PaginatedResult } from "../shared/types";
+import type {
+  AddAttachmentInput,
+  createNewsInput,
+  DeleteNewsInput,
+  GetManyNewsInput,
+  RemoveAttachmentInput,
+  updateNewsInput,
+  UpdatePreviewImage,
+} from "./schema";
+
+const create = async (input: createNewsInput) => {
+  return await postUsecase.create({
+    title: input.title,
+    body: input.body,
+    type: "news",
+  });
+};
+
+const update = async (input: updateNewsInput) => {
+  await postUsecase.update({
+    id: input.id,
+    title: input.title,
+    body: input.body,
+    type: "news",
+  });
+};
+
+const publish = async (id: string) => {
+  await postUsecase.publish(id);
+};
+
+const unpublish = async (id: string) => {
+  await postUsecase.unpublish(id);
+};
+
+const updatePreviewImage = async (input: UpdatePreviewImage) => {
+  await postUsecase.updatePreviewImage(input);
+};
+
+const addAttachment = async (input: AddAttachmentInput) => {
+  if (!(await postUsecase.getById(input.id))) {
+    throw new Error("News not found");
+  }
+
+  const metadata = await getFileStore().store(
+    Buffer.from(await input.file.arrayBuffer()),
+    {
+      mimeType: input.file.type,
+      name: input.file.name,
+    },
+  );
+
+  await db
+    .update(posts)
+    .set({
+      attachments: sql`array_append(attachments, ${JSON.stringify({
+        label: input.label,
+        file: { id: metadata.id, mimeType: input.file.type },
+        id: metadata.id,
+      })}::jsonb)`,
+    })
+    .where(eq(posts.id, input.id));
+};
+
+const removeAttachment = async (input: RemoveAttachmentInput) => {
+  await postUsecase.removeAttachment(input);
+};
+
+const getMany = async (
+  input: GetManyNewsInput,
+): Promise<PaginatedResult<Post>> => {
+  return await postUsecase.getMany({
+    ...input,
+    type: "news",
+  });
+};
+
+const getById = async (id: string): Promise<Post | undefined> => {
+  return await postUsecase.getById(id);
+};
+
+const deleteNews = async (input: DeleteNewsInput) => {
+  await postUsecase.deletePost(input);
+};
+
+export const newsUsecase = {
+  publish,
+  unpublish,
+  create,
+  update,
+  getMany,
+  getById,
+  updatePreviewImage,
+  addAttachment,
+  removeAttachment,
+  deleteNews,
+};

--- a/src/core/news/usecase.ts
+++ b/src/core/news/usecase.ts
@@ -1,6 +1,6 @@
 import { postUsecase } from "@/core/post/usecase";
-import type { Post } from "@/db/schema";
 import { db } from "@/db";
+import type { Post } from "@/db/schema";
 import { posts } from "@/db/schema";
 import { getFileStore } from "@/lib/storage";
 import { eq, sql } from "drizzle-orm";
@@ -61,7 +61,7 @@ const addAttachment = async (input: AddAttachmentInput) => {
     .update(posts)
     .set({
       attachments: sql`array_append(attachments, ${JSON.stringify({
-        label: input.label,
+        label: input.file.name || metadata.id,
         file: { id: metadata.id, mimeType: input.file.type },
         id: metadata.id,
       })}::jsonb)`,

--- a/src/hooks/news/mutation.ts
+++ b/src/hooks/news/mutation.ts
@@ -1,0 +1,136 @@
+import type {
+  AddAttachmentInput,
+  createNewsInput,
+  DeleteNewsInput,
+  RemoveAttachmentInput,
+  updateNewsInput,
+  UpdatePreviewImage,
+} from "@/core/news/schema";
+import { transformToFormData } from "@/lib/utils/form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { actions } from "astro:actions";
+
+export const useDeleteNews = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: DeleteNewsInput) => {
+      await actions.news.delete.orThrow(input);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const usePublishNews = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await actions.news.publish.orThrow(id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const useUnpublishNews = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await actions.news.unpublish.orThrow(id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const useCreateNews = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: createNewsInput) => {
+      await actions.news.create.orThrow(input);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const useUpdateNews = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: updateNewsInput) => {
+      await actions.news.update.orThrow(input);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const useUpdateNewsPreviewImage = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: UpdatePreviewImage) => {
+      const formData = new FormData();
+      transformToFormData(data, formData);
+      await actions.news.updatePreviewImage.orThrow(formData);
+      return;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const useAddNewsAttachment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: AddAttachmentInput) => {
+      const formData = new FormData();
+      transformToFormData(data, formData);
+      await actions.news.addAttachment.orThrow(formData);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const useRemoveNewsAttachment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: RemoveAttachmentInput) => {
+      await actions.news.removeAttachment.orThrow(data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["news"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};

--- a/src/hooks/news/queries.ts
+++ b/src/hooks/news/queries.ts
@@ -1,0 +1,22 @@
+import type { GetManyNewsInput } from "@/core/news/schema";
+import { useQuery } from "@tanstack/react-query";
+import { actions } from "astro:actions";
+
+export const useGetNews = (props: GetManyNewsInput) =>
+  useQuery({
+    queryKey: ["news", props],
+    queryFn: async () => {
+      const result = await actions.news.getMany.orThrow(props);
+      return result;
+    },
+  });
+
+export const useGetNewsById = ({ id }: { id: string | undefined }) =>
+  useQuery({
+    queryKey: ["news", id],
+    queryFn: async () => {
+      const result = await actions.news.getById.orThrow(id!);
+      return result;
+    },
+    enabled: !!id,
+  });

--- a/src/pages/admin/_index.tsx
+++ b/src/pages/admin/_index.tsx
@@ -1,12 +1,14 @@
 import { AnnouncementActionProvider } from "@/components/announcement/admin/announcement-action-context";
 import { DirectoryActionProvider } from "@/components/directory/admin/directory-action-context";
 import { SidebarLayout } from "@/components/layouts/sidebar";
+import { NewsActionProvider } from "@/components/news/admin/news-action-context";
 import { PersonActionProvider } from "@/components/person/admin/person-action-context";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Toaster } from "sonner";
 import AdminAnnouncementPage from "./announcements/_page";
 import AdminDirectoryPage from "./directory/_page";
+import AdminNewsPage from "./news/_page";
 import AdminPersonPage from "./persons/_page";
 
 const queryClient = new QueryClient();
@@ -26,6 +28,9 @@ export const AdminApp = () => {
                     path="announcements"
                     element={<AdminAnnouncementPage />}
                   />
+                </Route>
+                <Route element={<NewsActionProvider />}>
+                  <Route path="news" element={<AdminNewsPage />} />
                 </Route>
                 <Route element={<DirectoryActionProvider />}>
                   <Route path="directory" element={<AdminDirectoryPage />} />

--- a/src/pages/admin/news/_hooks.ts
+++ b/src/pages/admin/news/_hooks.ts
@@ -1,0 +1,118 @@
+import {
+  isDeleteNewsAction,
+  isPublishNewsAction,
+  isUnpublishNewsAction,
+  useNewsAction,
+} from "@/components/news/admin/news-action-context";
+import {
+  useDeleteNews,
+  usePublishNews,
+  useUnpublishNews,
+} from "@/hooks/news/mutation";
+import { useDebounce } from "@uidotdev/usehooks";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+
+export const useNewsFilters = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const parsedPublished = () => {
+    if (searchParams.get("published") === "true") return true;
+    if (searchParams.get("published") === "false") return false;
+    return undefined;
+  };
+
+  const [q, setQ] = useState("");
+  const [published, setPublished] = useState<boolean | undefined>(
+    parsedPublished,
+  );
+
+  const debouncedQ = useDebounce(q, 300);
+
+  useEffect(() => {
+    setSearchParams((prev) => ({
+      ...Object.fromEntries(prev),
+      ...(q ? { q } : {}),
+    }));
+  }, [debouncedQ]);
+
+  useEffect(() => {
+    setSearchParams((prev) => ({
+      ...Object.fromEntries(prev),
+      ...(published !== undefined ? { published: String(published) } : {}),
+    }));
+  }, [published]);
+
+  return {
+    q,
+    debouncedQ,
+    setQ,
+    published,
+    setPublished,
+  };
+};
+
+export const useNewsActions = () => {
+  const { newsAction } = useNewsAction();
+
+  const { mutate: _deleteNews, isPending: isDeleting } = useDeleteNews();
+
+  const { mutate: unpublish, isPending: isUnpublishing } = useUnpublishNews();
+  const { mutate: publish, isPending: isPublishing } = usePublishNews();
+
+  const publishNews = () => {
+    if (!isPublishNewsAction(newsAction)) {
+      return;
+    }
+    publish(newsAction.id, {
+      onSuccess: () => {
+        toast("News published successfully", {});
+      },
+      onError: () => {
+        toast.error("Something went wrong, please try again.");
+      },
+    });
+  };
+
+  const unpublishNews = () => {
+    if (!isUnpublishNewsAction(newsAction)) {
+      return;
+    }
+    unpublish(newsAction.id, {
+      onSuccess: () => {
+        toast("News unpublished successfully", {});
+      },
+      onError: (err) => {
+        toast.error(err?.message || "Something went wrong, please try again.");
+      },
+    });
+  };
+
+  const deleteNews = () => {
+    if (!isDeleteNewsAction(newsAction)) {
+      return;
+    }
+    _deleteNews(
+      { id: newsAction.id },
+      {
+        onSuccess: () => toast("News deleted successfully", {}),
+        onError: (err) => {
+          toast.error(
+            err?.message || "Something went wrong, please try again.",
+          );
+        },
+      },
+    );
+  };
+
+  return {
+    newsAction,
+    publishNews,
+    unpublishNews,
+    deleteNews,
+    isDeleting,
+    isUnpublishing,
+    isPublishing,
+  };
+};

--- a/src/pages/admin/news/_page.tsx
+++ b/src/pages/admin/news/_page.tsx
@@ -1,0 +1,189 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Sheet, SheetTrigger } from "@/components/ui/sheet";
+
+import { ActionConfirmDialog } from "@/components/common/action-confirm-dialog";
+import { Loader } from "@/components/common/loader";
+import { CreateNewsSheetContent } from "@/components/news/admin/create-news-sheet-content";
+import { EditNewsSheetContent } from "@/components/news/admin/edit-news-sheet-content";
+import {
+  isCreateNewsAction,
+  isDeleteNewsAction,
+  isPublishNewsAction,
+  isUnpublishNewsAction,
+  isUpdateNewsAction,
+  useNewsAction,
+} from "@/components/news/admin/news-action-context";
+import { newsColumns } from "@/components/news/admin/news-table-definition";
+import { Alert, AlertTitle } from "@/components/ui/alert";
+import { DataTable } from "@/components/ui/data-table";
+import {
+  useDeleteNews,
+  usePublishNews,
+  useUnpublishNews,
+} from "@/hooks/news/mutation";
+import { useGetNews } from "@/hooks/news/queries";
+import { useAddToasts } from "@/hooks/react-query";
+import { usePagination } from "@/hooks/use-pagination";
+import { CircleX, Plus } from "lucide-react";
+import { PaginationNav } from "../_components/pagination-nav";
+import { useNewsFilters } from "./_hooks";
+
+export default function AdminNewsPage() {
+  const { newsAction, setNewsAction } = useNewsAction();
+
+  const { mutate: deleteNews, isPending: isDeleting } = useAddToasts(
+    useDeleteNews,
+    {
+      successMessage: "ลบข่าวเรียบร้อย",
+      errorMessage: "เกิดข้อผิดพลาดในการลบข่าว",
+    },
+  );
+
+  const { mutate: unpublishNews, isPending: isUnpublishing } = useAddToasts(
+    useUnpublishNews,
+    {
+      successMessage: "ยกเลิกการเผยแพร่ข่าวเรียบร้อย",
+      errorMessage: "เกิดข้อผิดพลาดในการยกเลิกการเผยแพร่ข่าว",
+    },
+  );
+
+  const { mutate: publishNews, isPending: isPublishing } = useAddToasts(
+    usePublishNews,
+    {
+      successMessage: "เผยแพร่ข่าวเรียบร้อย",
+      errorMessage: "เกิดข้อผิดพลาดในการเผยแพร่ข่าว",
+    },
+  );
+
+  const filters = useNewsFilters();
+
+  const { page, nextPage, prevPage } = usePagination();
+
+  const { data, isLoading, error } = useGetNews({
+    page,
+    q: filters.debouncedQ,
+    published: filters.published,
+    orderBy: "createdAt",
+    direction: "desc",
+    pageSize: 20,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row gap-4 flex-1">
+        <Input
+          placeholder="ค้นหาข่าว..."
+          className="flex-1 sm:max-w-xs"
+          value={filters.q}
+          onChange={(e) => filters.setQ(e.target.value)}
+        />
+        <Select
+          value={
+            filters.published === undefined ? "all" : String(filters.published)
+          }
+          onValueChange={(value) => {
+            filters.setPublished(
+              value === "all" ? undefined : value === "true",
+            );
+          }}
+        >
+          <SelectTrigger className="flex-1 w-full sm:max-w-[150px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">ทั้งหมด</SelectItem>
+            <SelectItem value="true">เผยแพร่แล้ว</SelectItem>
+            <SelectItem value="false">ร่าง</SelectItem>
+          </SelectContent>
+        </Select>
+        <Sheet
+          onOpenChange={(open) =>
+            setNewsAction(open ? { type: "create" } : null)
+          }
+          open={isCreateNewsAction(newsAction)}
+        >
+          <SheetTrigger asChild className="sm:ml-auto flex-1 sm:flex-none">
+            <Button className="">
+              <Plus className="mr-2 h-4 w-4" />
+              <span>สร้างข่าวใหม่</span>
+            </Button>
+          </SheetTrigger>
+          <CreateNewsSheetContent
+            onClose={() =>
+              isCreateNewsAction(newsAction) && setNewsAction(null)
+            }
+          />
+        </Sheet>
+      </div>
+      {/* Table */}
+      <div className="rounded-md border w-full overflow-hidden min-w-0">
+        {isLoading ? (
+          <Loader />
+        ) : error ? (
+          <Alert variant="destructive">
+            <CircleX className="h-4 w-4 text-destructive" />
+            <AlertTitle>เกิดข้อผิดพลาดในการโหลดข่าว</AlertTitle>
+          </Alert>
+        ) : (
+          <DataTable columns={newsColumns} data={data?.items || []} />
+        )}
+      </div>
+      {!isLoading && data && (
+        <PaginationNav
+          page={data.page}
+          totalPages={data.totalPages}
+          onNextPage={nextPage}
+          onPrevPage={prevPage}
+        />
+      )}
+      {/* Sheet */}
+      <Sheet
+        open={isUpdateNewsAction(newsAction)}
+        onOpenChange={(open) => !open && setNewsAction(null)}
+      >
+        <EditNewsSheetContent
+          onClose={() => isUpdateNewsAction(newsAction) && setNewsAction(null)}
+          id={isUpdateNewsAction(newsAction) ? newsAction.id : undefined}
+        />
+      </Sheet>
+      <ActionConfirmDialog
+        open={isDeleteNewsAction(newsAction)}
+        onOpenChange={() => setNewsAction(null)}
+        onConfirm={() =>
+          isDeleteNewsAction(newsAction) && deleteNews({ id: newsAction.id })
+        }
+        isPending={isDeleting}
+        Title="คุณแน่ใจหรือว่าต้องการลบข่าวนี้?"
+        Description="การดำเนินการนี้ไม่สามารถย้อนกลับได้"
+      />
+      <ActionConfirmDialog
+        open={isUnpublishNewsAction(newsAction)}
+        onOpenChange={() => setNewsAction(null)}
+        onConfirm={() =>
+          isUnpublishNewsAction(newsAction) && unpublishNews(newsAction.id)
+        }
+        isPending={isUnpublishing}
+        Title="คุณแน่ใจหรือว่าต้องการยกเลิกการเผยแพร่ข่าวนี้?"
+        Description="การดำเนินการนี้จะทำให้ข่าวนี้กลับไปเป็นร่าง"
+      />
+      <ActionConfirmDialog
+        open={isPublishNewsAction(newsAction)}
+        onOpenChange={() => setNewsAction(null)}
+        onConfirm={() =>
+          isPublishNewsAction(newsAction) && publishNews(newsAction.id)
+        }
+        isPending={isPublishing}
+        Title="คุณแน่ใจหรือว่าต้องการเผยแพร่ข่าวนี้?"
+        Description="การดำเนินการนี้จะทำให้ข่าวนี้เผยแพร่ต่อสาธารณะ"
+      />
+    </div>
+  );
+}

--- a/src/pages/news/[id].astro
+++ b/src/pages/news/[id].astro
@@ -1,0 +1,122 @@
+---
+export const prerender = false;
+
+import PublicLayout from "@/layouts/public-layout.astro";
+import { newsUsecase } from "@/core/news/usecase";
+import { Button } from "@/components/ui/button";
+import { Image } from "astro:assets";
+import { Config } from "@/config";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+
+const { id } = Astro.params;
+
+if (!id) {
+  return Astro.redirect("/404");
+}
+
+const news = await newsUsecase.getById(id);
+
+if (!news || !news.publishedAt) {
+  return Astro.redirect("/404");
+}
+
+// SEO metadata
+const title = news.seo?.title || `ข่าวสาร – ${news.title}`;
+const description = news.seo?.ogImage ? `ข่าวสาร: ${news.title}` : undefined;
+const ogImage = news.seo?.ogImage
+  ? `/api/files/${news.seo.ogImage}`
+  : undefined;
+---
+
+<PublicLayout>
+  <Fragment slot="head">
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    {ogImage && <meta property="og:image" content={ogImage} />}
+    <meta property="og:title" content={title} />
+    {description && <meta property="og:description" content={description} />}
+    <meta property="og:type" content="article" />
+    <link rel="canonical" href={new URL(`/news/${id}`, Astro.url)} />
+  </Fragment>
+
+  <main slot="body" class="container mx-auto px-4 py-8">
+    <article class="max-w-4xl mx-auto">
+      <header class="mb-8">
+        <div class="flex items-center justify-between mb-4">
+          <Button variant="ghost" size="sm" asChild>
+            <a href="/news" class="flex items-center gap-2">
+              <svg
+                class="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M15 19l-7-7 7-7"></path>
+              </svg>
+              กลับไปข่าวสารทั้งหมด
+            </a>
+          </Button>
+        </div>
+        <h1 class="text-3xl md:text-4xl font-bold leading-tight mb-2">
+          {news.title}
+        </h1>
+        {
+          news.publishedAt && (
+            <p class="text-lg text-muted-foreground mb-3">
+              เผยแพร่เมื่อ{" "}
+              {new Date(news.publishedAt).toLocaleDateString("th-TH")}
+            </p>
+          )
+        }
+      </header>
+
+      {
+        news.previewImage && (
+          <figure class="mb-8">
+            <Image
+              src={Config.getFileURL(news.previewImage.id)}
+              alt={news.title}
+              class="w-full h-auto"
+              width={800}
+              height={450}
+            />
+          </figure>
+        )
+      }
+
+      {
+        news.body && (
+          <div class="prose prose-lg max-w-none mb-8">
+            <div class="whitespace-pre-wrap text-foreground leading-relaxed">
+              {news.body}
+            </div>
+          </div>
+        )
+      }
+
+      {
+        news.attachments && news.attachments.length > 0 && (
+          <section class="mb-8">
+            <h2 class="text-xl font-semibold mb-4">รูปภาพเพิ่มเติม</h2>
+            <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {news.attachments.map((attachment) => (
+                <Image
+                  src={Config.getFileURL(attachment.file.id)}
+                  alt={attachment.label || news.title}
+                  class="object-contain w-full h-auto"
+                  width={400}
+                  height={400}
+                />
+              ))}
+            </div>
+          </section>
+        )
+      }
+    </article>
+  </main>
+</PublicLayout>
+

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,0 +1,63 @@
+---
+export const prerender = false;
+
+import PublicLayout from "@/layouts/public-layout.astro";
+import { newsUsecase } from "@/core/news/usecase";
+import PaginationNav from "@/components/common/pagination-nav.astro";
+import { NewsCard } from "@/components/news/news-card";
+
+const url = new URL(Astro.request.url);
+const searchParams = url.searchParams;
+
+const pageParam = searchParams.get("page");
+const page = pageParam ? parseInt(pageParam, 10) || 1 : 1;
+
+const pageSize = 20;
+
+// Get published news ordered by publishedAt desc
+const result = await newsUsecase.getMany({
+  published: true,
+  pageSize,
+  page,
+  orderBy: "publishedAt",
+  direction: "desc",
+});
+---
+
+<PublicLayout>
+  <Fragment slot="head">
+    <title>ข่าวสาร – มณฑลทหารบกที่ 16</title>
+    <meta name="description" content="ข่าวสารและข้อมูลสำคัญจากมณฑลทหารบกที่ 16" />
+  </Fragment>
+
+  <main slot="body" class="container mx-auto px-4 py-8">
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold text-foreground mb-2">ข่าวสาร</h1>
+      <p class="text-muted-foreground">
+        ข่าวสารและข้อมูลสำคัญจากมณฑลทหารบกที่ 16
+      </p>
+    </div>
+
+    {
+      result.items && result.items.length > 0 ? (
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {result.items.map((news) => (
+            <NewsCard news={news} />
+          ))}
+        </div>
+      ) : (
+        <div class="text-center py-12">
+          <p class="text-lg text-muted-foreground">ยังไม่มีข่าวสาร</p>
+        </div>
+      )
+    }
+    <div class="mt-8">
+      <PaginationNav
+        basePath="/news"
+        page={page}
+        totalPages={result.totalPages}
+        pageSize={pageSize}
+      />
+    </div>
+  </main>
+</PublicLayout>


### PR DESCRIPTION
This pull request introduces a comprehensive news management feature, including backend actions and frontend components for creating, editing, viewing, and administrating news items. The changes add support for news CRUD operations, preview images, attachments, publishing workflows, and a React context for news actions.

**Backend: News Actions API**

- Added a new `news` action module in `src/actions/news.ts` that provides server-side handlers for creating, updating, deleting, publishing, unpublishing, and retrieving news, all with authentication and schema validation.
- Registered the new `news` action in the main `server` export in `src/actions/index.ts`.

**Frontend: News Administration UI**

- Added `CreateNewsSheetContent` and `EditNewsSheetContent` React components for admin users to create and edit news, including forms for metadata, preview image upload, and managing attachments. [[1]](diffhunk://#diff-06e5fa01ebb633ff149a324aca973fc25ffd4c5d2e303bd90e14fc18ab2140f6R1-R109) [[2]](diffhunk://#diff-ba44767726b068fb82f8f28731a3046a7609b53399df7b7951ebfbae212183d8R1-R354)
- Implemented a `newsColumns` definition for a news admin table, supporting status badges, attachment counts, and row actions (edit, delete, publish/unpublish) using a new React context. [[1]](diffhunk://#diff-1ddcabf886940bbcb668114b9845d94613d331e1b7ea55bc3cfa71525462951eR1-R85) [[2]](diffhunk://#diff-2cf811b4a5301e1ca80d92174f00d0776c4c2658b3ebc9206a7e3d3a66f50e38R1-R59)
- Introduced a `NewsActionProvider` and related context utilities to manage modal/dialog state for news actions across the admin interface.

**Frontend: Public News Display**

- Added a `NewsCard` component for displaying news items with preview images, titles, and publication dates in a card layout.

---

**Backend: News Actions API**
- Implemented full CRUD, attachment, and publishing APIs for news in `src/actions/news.ts`, with authentication and error handling.
- Registered the `news` action in the main server actions export.

**Frontend: News Administration UI**
- Added `CreateNewsSheetContent` and `EditNewsSheetContent` components for admin news management, including metadata, image, and attachments forms. [[1]](diffhunk://#diff-06e5fa01ebb633ff149a324aca973fc25ffd4c5d2e303bd90e14fc18ab2140f6R1-R109) [[2]](diffhunk://#diff-ba44767726b068fb82f8f28731a3046a7609b53399df7b7951ebfbae212183d8R1-R354)
- Defined `newsColumns` for the admin news table with action buttons and status/attachment indicators.
- Introduced `NewsActionProvider` and related context utilities for managing news-related modal/dialog state.

**Frontend: Public News Display**
- Created a `NewsCard` component for public-facing news display with preview image and metadata.