### PR TITLE
perf(pages): add caching headers for improved performance

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = false;
 import PublicLayout from "@/layouts/public-layout.astro";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -70,6 +71,15 @@ const armyProvinceHistoryItems = [
       "ในปี พ.ศ. 2552 กระทรวงกลาโหมออกกฎกระทรวงจัดตั้งมณฑลทหารบกที่ 15 (มทบ.15) โดยแปรสภาพมาจาก จทบ.พ.บ. ตาม อจย. หมายเลข 51–201 มีผลบังคับใช้ตั้งแต่วันที่ 1 เมษายน พ.ศ. 2552 ครอบคลุมพื้นที่รับผิดชอบจังหวัดราชบุรีและจังหวัดสมุทรสงคราม พร้อมทั้งปรับตำแหน่งผู้บัญชาการจากพันเอกพิเศษเป็นพลตรี",
   },
 ];
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=86400, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=86400, stale-while-revalidate=86400",
+);
 ---
 
 <PublicLayout>
@@ -86,7 +96,9 @@ const armyProvinceHistoryItems = [
       <HeroSection
         client:visible
         bg1Src={bg1Optimized.src}
-        heroImage={config?.aboutUsHeroImage ? Config.getFileURL(config.aboutUsHeroImage.id) : undefined}
+        heroImage={config?.aboutUsHeroImage
+          ? Config.getFileURL(config.aboutUsHeroImage.id)
+          : undefined}
       />
 
       <Separator />

--- a/src/pages/announcements/[id].astro
+++ b/src/pages/announcements/[id].astro
@@ -29,6 +29,15 @@ const description = announcement.seo?.ogImage
 const ogImage = announcement.seo?.ogImage
   ? `/api/files/${announcement.seo.ogImage}`
   : undefined;
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=31536000, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=31536000, stale-while-revalidate=604800",
+);
 ---
 
 <PublicLayout>

--- a/src/pages/announcements/index.astro
+++ b/src/pages/announcements/index.astro
@@ -33,6 +33,15 @@ const result = await annouyncementsUsecase.getMany({
   tags: selectedTags.length > 0 ? selectedTags : undefined,
   year: selectedYear ? parseInt(selectedYear, 10) : undefined,
 });
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=86400, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=86400, stale-while-revalidate=86400",
+);
 ---
 
 <PublicLayout>

--- a/src/pages/api/files/[id].ts
+++ b/src/pages/api/files/[id].ts
@@ -19,6 +19,9 @@ export const GET: APIRoute = async ({ params, request }) => {
     status: 200,
     headers: {
       "Content-Type": metadata?.mimeType || "application/octet-stream",
+      "Cache-Control": "public, max-age=31536000, immutable", // 1 year
+      "Netlify-CDN-Cache-Control":
+        "public, durable, s-maxage=31536000, stale-while-revalidate=604800",
     },
   });
 };

--- a/src/pages/directory/index.astro
+++ b/src/pages/directory/index.astro
@@ -25,6 +25,15 @@ const result = await directoryUsecase.getMany({
   page,
 });
 const items = result.items;
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=86400, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=86400, stale-while-revalidate=86400",
+);
 ---
 
 <PublicLayout>
@@ -76,4 +85,3 @@ const items = result.items;
     </div>
   </main>
 </PublicLayout>
-

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = false;
 import { Slogan } from "./_components/slogan";
 import {
   Card,
@@ -44,6 +45,15 @@ const commander = await personUsecase.getByOrder(1);
 if (commander?.portrait) {
   commander.portrait = Config.getFileURL(commander.portrait);
 }
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=86400, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=86400, stale-while-revalidate=86400",
+);
 ---
 
 <PublicLayout>

--- a/src/pages/leadership.astro
+++ b/src/pages/leadership.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = false;
 import PublicLayout from "@/layouts/public-layout.astro";
 import LeadershipTree from "@/components/person/leadership-tree";
 import { personUsecase } from "@/core/person/usecase";
@@ -11,6 +12,15 @@ const levels = await personUsecase.getPersonRankTree().then((levels) =>
       portrait: person.portrait ? Config.getFileURL(person.portrait) : null,
     })),
   ),
+);
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=86400, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=86400, stale-while-revalidate=86400",
 );
 ---
 

--- a/src/pages/news/[id].astro
+++ b/src/pages/news/[id].astro
@@ -26,6 +26,15 @@ const description = news.seo?.ogImage ? `ข่าวสาร: ${news.title}` :
 const ogImage = news.seo?.ogImage
   ? `/api/files/${news.seo.ogImage}`
   : undefined;
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=31536000, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=31536000, stale-while-revalidate=604800",
+);
 ---
 
 <PublicLayout>
@@ -119,4 +128,3 @@ const ogImage = news.seo?.ogImage
     </article>
   </main>
 </PublicLayout>
-

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -22,12 +22,24 @@ const result = await newsUsecase.getMany({
   orderBy: "publishedAt",
   direction: "desc",
 });
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=86400, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=86400, stale-while-revalidate=86400",
+);
 ---
 
 <PublicLayout>
   <Fragment slot="head">
     <title>ข่าวสาร – มณฑลทหารบกที่ 16</title>
-    <meta name="description" content="ข่าวสารและข้อมูลสำคัญจากมณฑลทหารบกที่ 16" />
+    <meta
+      name="description"
+      content="ข่าวสารและข้อมูลสำคัญจากมณฑลทหารบกที่ 16"
+    />
   </Fragment>
 
   <main slot="body" class="container mx-auto px-4 py-8">
@@ -61,3 +73,4 @@ const result = await newsUsecase.getMany({
     </div>
   </main>
 </PublicLayout>
+

--- a/src/pages/procurement/index.astro
+++ b/src/pages/procurement/index.astro
@@ -24,6 +24,15 @@ const result = await procurementUsecase.getMany({
   orderBy: "date",
   direction: "desc",
 });
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=86400, must-revalidate",
+);
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, durable, s-maxage=86400, stale-while-revalidate=86400",
+);
 ---
 
 <PublicLayout>
@@ -88,4 +97,3 @@ const result = await procurementUsecase.getMany({
     </div>
   </main>
 </PublicLayout>
-


### PR DESCRIPTION
- Disable prerendering for dynamic pages (about, index, leadership)
- Add Cache-Control and Netlify-CDN-Cache-Control headers to all public pages
- Add long-term caching headers to file API endpoint
- Minor formatting adjustments